### PR TITLE
[FIX] allowing multiple templates to be associated to the same model

### DIFF
--- a/serveraction.py
+++ b/serveraction.py
@@ -70,15 +70,16 @@ class actions_server(osv.osv):
 
         for action in self.browse(cr, uid, ids, context):
             obj_pool = self.pool.get(action.model_id.model)
-            obj = obj_pool.browse(cr, uid, context['active_id'], context=context)
             cxt = {
                 'context':context,
-                'object': obj,
                 'time':time,
                 'cr': cr,
                 'pool' : self.pool,
                 'uid' : uid
             }
+            if context.get('active_id', False):
+                obj = obj_pool.browse(cr, uid, context['active_id'], context=context)
+                cxt['object'] = obj
             expr = eval(str(action.condition), cxt)
             if not expr:
                 continue


### PR DESCRIPTION
These changes allow to associate more than one template to the same model.
Without these, if you create 2 templates for the same model and set them as 'send on create', only one of them will be processed.

This also fixes the following regression:
https://github.com/openlabs/poweremail/commit/a8569d351a5c4fc4e2482aa3b0eec4149ee3df37#L0L952
