### PR TITLE
[FIX] Prevent TypeError in pem_from field in OpenERP 6.1

### DIFF
--- a/send_wizard.py
+++ b/send_wizard.py
@@ -229,6 +229,8 @@ class poweremail_send_wizard(osv.osv_memory):
 
         for id in context['src_rec_ids']:
             accounts = self.pool.get('poweremail.core_accounts').read(cr, uid, screen_vals['from'], context=context)
+            if type(accounts) == list:
+                accounts = accounts[0]
             vals = {
                 'pem_from': tools.ustr(accounts['name']) + "<" + tools.ustr(accounts['email_id']) + ">",
                 'pem_to': get_end_value(id, screen_vals['to']),


### PR DESCRIPTION
In OpenERP 6.1, when I'm trying to send a email from a wizard (sale order), this error is launched:

```
Server Traceback (most recent call last):
  File "/python/openerp-6.1-1/openerp/addons/web/common/http.py", line 592, in send
    result = openerp.netsvc.dispatch_rpc(service_name, method, args)
  File "/python/openerp-6.1-1/openerp/netsvc.py", line 360, in dispatch_rpc
    result = ExportService.getService(service_name).dispatch(method, params)
  File "/python/openerp-6.1-1/openerp/service/web_services.py", line 572, in dispatch
    res = fn(db, uid, *params)
  File "/python/openerp-6.1-1/openerp/osv/osv.py", line 167, in execute_kw
    return self.execute(db, uid, obj, method, *args, **kw or {})
  File "/python/openerp-6.1-1/openerp/osv/osv.py", line 121, in wrapper
    return f(self, dbname, *args, **kwargs)
  File "/python/openerp-6.1-1/openerp/osv/osv.py", line 176, in execute
    res = self.execute_cr(cr, uid, obj, method, *args, **kw)
  File "/python/openerp-6.1-1/openerp/osv/osv.py", line 164, in execute_cr
    return getattr(object, method)(cr, uid, *args, **kw)
  File "/python/openerp-6.1-1/extra-addons/poweremail/send_wizard.py", line 187, in send_mail
    mailid = self.save_to_mailbox(cr, uid, ids, context)
  File "/python/openerp-6.1-1/extra-addons/poweremail/send_wizard.py", line 233, in save_to_mailbox
    'pem_from': tools.ustr(accounts['name']) + "<" + tools.ustr(accounts['email_id']) + ">",
TypeError: list indices must be integers, not str
```

With this fix prevent this error.
