### PR TITLE
Error on Send mail Wizard

### DIFF
--- a/send_wizard.py
+++ b/send_wizard.py
@@ -228,9 +228,9 @@ class poweremail_send_wizard(osv.osv_memory):
             context['src_rec_ids'] = context['src_rec_ids'][:1]
 
         for id in context['src_rec_ids']:
-            accounts = self.pool.get('poweremail.core_accounts').read(cr, uid, screen_vals['from'], context=context)
+            accounts = self.pool.get('poweremail.core_accounts').browse(cr, uid, screen_vals['from'], context=context)
             vals = {
-                'pem_from': tools.ustr(accounts['name']) + "<" + tools.ustr(accounts['email_id']) + ">",
+                'pem_from': tools.ustr(accounts.name) + "<" + tools.ustr(accounts.email_id) + ">",
                 'pem_to': get_end_value(id, screen_vals['to']),
                 'pem_cc': get_end_value(id, screen_vals['cc']),
                 'pem_bcc': get_end_value(id, screen_vals['bcc']),


### PR DESCRIPTION
Send mail Wizard raises the following exception because 'read' method returns a list

  File "/home/elbati/workspace/openerp/6.1/server/openerp/addons/poweremail/send_wizard.py", line 187, in send_mail
    mailid = self.save_to_mailbox(cr, uid, ids, context)
  File "/home/elbati/workspace/openerp/6.1/server/openerp/addons/poweremail/send_wizard.py", line 233, in save_to_mailbox
    'pem_from': tools.ustr(accounts.name) + "<" + tools.ustr(accounts.email_id) + ">",
TypeError: list indices must be integers, not str
