### PR TITLE
Error on Send mail Wizard: correctly fix for OpenERP 6.1

### DIFF
--- a/send_wizard.py
+++ b/send_wizard.py
@@ -228,7 +228,7 @@ class poweremail_send_wizard(osv.osv_memory):
             context['src_rec_ids'] = context['src_rec_ids'][:1]
 
         for id in context['src_rec_ids']:
-            accounts = self.pool.get('poweremail.core_accounts').read(cr, uid, screen_vals['from'], context=context)
+            accounts = self.pool.get('poweremail.core_accounts').read(cr, uid, int(screen_vals['from']), context=context)
             vals = {
                 'pem_from': tools.ustr(accounts['name']) + "<" + tools.ustr(accounts['email_id']) + ">",
                 'pem_to': get_end_value(id, screen_vals['to']),


### PR DESCRIPTION
Function read in orm check type of id(s) and if type is int, long or dict return one record else return list of record. In this case value of screen_vals['from'] must be integer!
